### PR TITLE
Configure DCN nodes as clients of the central Ceph cluster

### DIFF
--- a/glance/ansible/run.sh
+++ b/glance/ansible/run.sh
@@ -3,6 +3,7 @@
 source ~/stackrc
 STACKS="control-plane,dcn0,dcn1"
 export ANSIBLE_DEPRECATION_WARNINGS=0
+export ANSIBLE_LOG_PATH="ansible.log"
 INV=inventory.yml
 if [[ ! -e $INV ]]; then
     tripleo-ansible-inventory --static-yaml-inventory $INV --stack $STACKS

--- a/glance/ansible/site.yml
+++ b/glance/ansible/site.yml
@@ -19,7 +19,7 @@
       loop:
         - { ceph_cluster_name: 'dcn0', ceph_cluster_host: 'dcn0-distributedcomputehci-0' }
         #- { ceph_cluster_name: 'dcn1', ceph_cluster_host: 'dcn1-distributedcomputehci-0' }
-        - { ceph_cluster_name: 'ceph', ceph_cluster_host: 'control-plane-controller-0' }
+        - { ceph_cluster_name: 'central', ceph_cluster_host: 'control-plane-controller-0' }
 
 - name: Configure all Ceph clients
   gather_facts: false
@@ -33,7 +33,7 @@
         ceph_cluster_host: "{{ item.ceph_cluster_host }}"
       loop:
         - { ceph_cluster_name: 'dcn0', ceph_cluster_host: 'dcn0-distributedcomputehci-0' }
-        - { ceph_cluster_name: 'ceph', ceph_cluster_host: 'control-plane-controller-0' }
+        - { ceph_cluster_name: 'central', ceph_cluster_host: 'control-plane-controller-0' }
         #- { ceph_cluster_name: 'dcn1', ceph_cluster_host: 'dcn1-distributedcomputehci-0' }
 
 - name: Configure glance with backends

--- a/glance/ansible/site.yml
+++ b/glance/ansible/site.yml
@@ -6,37 +6,40 @@
   tasks:
     - include_tasks: tasks/prepare.yml
 
-- name: Extract Ceph data from DCN servers
+- name: Extract keyring and config from all Ceph clusters
   gather_facts: false
-  hosts: dcn0-distributedcomputehci-0 #dcn1-distributedcomputehci-0
+  hosts: control-plane-controller-0 dcn0-distributedcomputehci-0 #dcn1-distributedcomputehci-0
   become: true
   tags: pull
   tasks:
     - include_tasks: tasks/make_client.yml
       vars:
-        dcn: "{{ item.dcn }}"
-        host: "{{ item.host }}"
+        ceph_cluster_name: "{{ item.ceph_cluster_name }}"
+        ceph_cluster_host: "{{ item.ceph_cluster_host }}"
       loop:
-        - { dcn: 'dcn0', host: 'dcn0-distributedcomputehci-0' }
-        #- { dcn: 'dcn1', host: 'dcn1-distributedcomputehci-0' }
-        
-- name: Configure central control plane as DCN Ceph cluster client
+        - { ceph_cluster_name: 'dcn0', ceph_cluster_host: 'dcn0-distributedcomputehci-0' }
+        #- { ceph_cluster_name: 'dcn1', ceph_cluster_host: 'dcn1-distributedcomputehci-0' }
+        - { ceph_cluster_name: 'ceph', ceph_cluster_host: 'control-plane-controller-0' }
+
+- name: Configure all Ceph clients
   gather_facts: false
   become: true
-  hosts: control-plane-controller-0
+  hosts: control-plane-controller-0 dcn0-distributedcomputehci-0 #dcn1-distributedcomputehci-0
   tags: push
   tasks:
     - include_tasks: tasks/install_client.yml
       vars:
-        dcn: "{{ item }}"
+        ceph_cluster_name: "{{ item.ceph_cluster_name }}"
+        ceph_cluster_host: "{{ item.ceph_cluster_host }}"
       loop:
-        - dcn0
-        #- dcn1
+        - { ceph_cluster_name: 'dcn0', ceph_cluster_host: 'dcn0-distributedcomputehci-0' }
+        - { ceph_cluster_name: 'ceph', ceph_cluster_host: 'control-plane-controller-0' }
+        #- { ceph_cluster_name: 'dcn1', ceph_cluster_host: 'dcn1-distributedcomputehci-0' }
 
-- name: Configure central control plane with extra glance backends
+- name: Configure glance with backends
   gather_facts: false
   become: true
-  hosts: control-plane-controller-0
+  hosts: control-plane-controller-0 dcn0-distributedcomputehci-0 #dcn1-distributedcomputehci-0
   tags:
     - glance
     - glance_backends
@@ -45,9 +48,9 @@
       vars:
         glance_conf: "/var/lib/config-data/puppet-generated/glance_api/etc/glance/glance-api.conf"
         rc: /home/heat-admin/control-planerc
-        dcns:
+        dcn_list:
           - dcn0
-          #- dcn1
+          # - dcn1
 
 - name: Configure all glance services with experimental feature
   gather_facts: false

--- a/glance/ansible/site.yml
+++ b/glance/ansible/site.yml
@@ -64,7 +64,7 @@
       vars:
         import_multi_stores: True
         copy_existing_image: False
-        force_container: True
+        force_container: False
         glance_container_url: 192.168.24.1:8787/tripleomaster/centos-binary-glance-api
         random_tag: "{{ lookup('file', '../patch_glance/RAND') }}"
         glance_conf: "/var/lib/config-data/puppet-generated/glance_api/etc/glance/glance-api.conf"

--- a/glance/ansible/tasks/glance_backends.yml
+++ b/glance/ansible/tasks/glance_backends.yml
@@ -39,16 +39,16 @@
     section: glance_store
     state: absent
 
-- name: Set default_backend
+- name: Set default_backend and central central_rbd_store_user
   set_fact:
     default_backend: central
-    rbd_store_user: openstasck
+    central_rbd_store_user: openstack # central uses default key from initial install
   when: inventory_hostname == "control-plane-controller-0"
 
-- name: Set default backend for dcn hosts based on hostname
+- name: Set default_backend and central_rbd_store_user for dcn hosts based on hostname
   set_fact:
     default_backend: "{{ inventory_hostname.split('-')[0] }}"
-    rbd_store_user: ceph.glance # from ceph cluster name of make_client.yml
+    central_rbd_store_user: central.glance # from ceph cluster name of make_client.yml
   when: inventory_hostname is regex("^dcn[0-9]+")
 
 - name: Add new glance_store and central sections
@@ -62,10 +62,10 @@
       [central]
       store_description = "central RBD backend"
       rbd_store_pool = images
-      rbd_store_user = {{ rbd_store_user }}
-      rbd_store_ceph_conf = /etc/ceph/ceph.conf
+      rbd_store_user = {{ central_rbd_store_user }}
+      rbd_store_ceph_conf = /etc/ceph/central.conf
 
-- name: Add new DCN sections
+- name: Add new DCN sections for central node
   blockinfile:
     path: "{{ glance_conf }}"
     block: |
@@ -76,6 +76,22 @@
       rbd_store_ceph_conf = /etc/ceph/{{ item }}.conf
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item }}"
   loop: "{{ dcns }}"
+  when:
+    - inventory_hostname == "control-plane-controller-0"
+
+- name: Add DCN section for the DCN node
+  blockinfile:
+    path: "{{ glance_conf }}"
+    block: |
+      [{{ item }}]
+      store_description = "{{ item }} RBD backend"
+      rbd_store_pool = images
+      rbd_store_user = openstack
+      rbd_store_ceph_conf = /etc/ceph/{{ item }}.conf
+    marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item }}"
+  loop: "{{ dcns }}"
+  when:
+    - inventory_hostname is regex("^dcn[0-9]+")
 
 - name: restart glance container
   shell: "systemctl restart tripleo_glance_api.service"

--- a/glance/ansible/tasks/glance_backends.yml
+++ b/glance/ansible/tasks/glance_backends.yml
@@ -1,4 +1,24 @@
 ---
+# dcns variable should only contain the current host
+# unless inventory_hostname is control-plane-controller-0
+- name: Set dcns list for non-control-plane glance
+  set_fact:
+    dcns: # rely on convention
+      - "{{ inventory_hostname.split('-')[0] }}"
+  when:
+    - inventory_hostname != "control-plane-controller-0"
+
+- name: Set dcns list for control-plane glance
+  # just using dcn_list doesn't work because of how include_tasks works
+  set_fact:
+    dcns: "{{ dcn_list }}"
+  when:
+    - inventory_hostname == "control-plane-controller-0"
+
+- name: State what is about to happen
+  debug:
+    msg: "Configure {{ inventory_hostname }} to use central and {{ dcns }} "
+
 - name: add enabled_backends to DEFAULT section
   ini_file:
     path: "{{ glance_conf }}"
@@ -19,6 +39,18 @@
     section: glance_store
     state: absent
 
+- name: Set default_backend
+  set_fact:
+    default_backend: central
+    rbd_store_user: openstasck
+  when: inventory_hostname == "control-plane-controller-0"
+
+- name: Set default backend for dcn hosts based on hostname
+  set_fact:
+    default_backend: "{{ inventory_hostname.split('-')[0] }}"
+    rbd_store_user: ceph.glance # from ceph cluster name of make_client.yml
+  when: inventory_hostname is regex("^dcn[0-9]+")
+
 - name: Add new glance_store and central sections
   blockinfile:
     path: "{{ glance_conf }}"
@@ -26,11 +58,11 @@
       [glance_store]
       stores=http,rbd
       os_region_name=regionOne
-      default_backend = central
+      default_backend = {{ default_backend }}
       [central]
       store_description = "central RBD backend"
       rbd_store_pool = images
-      rbd_store_user = openstack
+      rbd_store_user = {{ rbd_store_user }}
       rbd_store_ceph_conf = /etc/ceph/ceph.conf
 
 - name: Add new DCN sections
@@ -44,14 +76,17 @@
       rbd_store_ceph_conf = /etc/ceph/{{ item }}.conf
     marker: "# {mark} ANSIBLE MANAGED BLOCK {{ item }}"
   loop: "{{ dcns }}"
-  
+
 - name: restart glance container
   shell: "systemctl restart tripleo_glance_api.service"
 
-- name: query glance stores-info
-  shell: "source {{ rc }}; glance stores-info"
-  register: stores_info
+- when:
+    - inventory_hostname == "control-plane-controller-0"
+  block:
+    - name: query central glance stores-info
+      shell: "source {{ rc }}; glance stores-info"
+      register: stores_info
 
-- name: show stores_info
-  debug:
-    msg: "{{ stores_info.stdout_lines }}"
+    - name: show stores_info
+      debug:
+        msg: "{{ stores_info.stdout_lines }}"

--- a/glance/ansible/tasks/glance_features.yml
+++ b/glance/ansible/tasks/glance_features.yml
@@ -48,14 +48,6 @@
     option: debug
     value: "true"
 
-- name: Set default backend for dcn hosts based on hostname
-  ini_file:
-    path: "{{ glance_conf }}"
-    section: glance_store
-    option: default_backend
-    value: "{{ inventory_hostname[0:4] }}"
-  when: inventory_hostname is regex("^dcn[0-9]+")
-  
 - name: restart service glance container and issue daemon-reload to pick up config change
   systemd:
     state: restarted

--- a/glance/ansible/tasks/install_client.yml
+++ b/glance/ansible/tasks/install_client.yml
@@ -1,73 +1,84 @@
 ---
-- name: set conf path fact
-  set_fact:
-    conf: "/etc/ceph/{{ dcn }}.conf"
+- when:
+    # does not need to be configured to talk to itself
+    - ceph_cluster_host != inventory_hostname
+    # dcn nodes do not talk to eachother
+    - not (ceph_cluster_host|regex_search("^dcn") and
+           inventory_hostname|regex_search("^dcn"))
+  block:
+  - name: State what is about to happen
+    debug:
+      msg: "configure {{ inventory_hostname }} to use ceph cluster: {{ ceph_cluster_name }}"
 
-- name: upload control-planerc (ignore attrs were not transferred)
-  synchronize:
-    mode: push
-    dest: "/home/heat-admin/control-planerc"
-    src: "dcn_ceph_data/control-planerc"
+  - name: Set conf path fact
+    set_fact:
+      conf: "/etc/ceph/{{ ceph_cluster_name }}.conf"
 
-- name: upload ceph configuration files (ignore attrs were not transferred)
-  synchronize:
-    mode: push
-    dest: "{{ conf }}"
-    src: "dcn_ceph_data/{{ dcn }}.conf"
+  - name: Upload control-planerc (ignore attrs were not transferred)
+    synchronize:
+      mode: push
+      dest: "/home/heat-admin/control-planerc"
+      src: "dcn_ceph_data/control-planerc"
 
-- name: set keyring path fact
-  set_fact:
-    keyring: "/etc/ceph/client.{{ dcn }}.glance.keyring"
+  - name: Upload ceph configuration files (ignore attrs were not transferred)
+    synchronize:
+      mode: push
+      dest: "{{ conf }}"
+      src: "dcn_ceph_data/{{ ceph_cluster_name }}.conf"
 
-- name: add client section in conf file with path to keyring
-  ini_file:
-    path: "{{ conf }}"
-    section: client
-    option: keyring
-    value: "{{ keyring }}"
-    
-- name: chown dcn conf file
-  shell: "chown root:root {{ conf }}"
-  
-- name: upload ceph keyrings
-  synchronize:
-    mode: push
-    dest: "{{ keyring }}"
-    src: "dcn_ceph_data/client.{{ dcn }}.glance.keyring"
+  - name: Set keyring path fact
+    set_fact:
+      keyring: "/etc/ceph/client.{{ ceph_cluster_name }}.glance.keyring"
 
-- name: chown dcn keyring
-  shell: "chown 167:167 {{ keyring }}"
+  - name: Add client section in conf file with path to keyring
+    ini_file:
+      path: "{{ conf }}"
+      section: client
+      option: keyring
+      value: "{{ keyring }}"
 
-- name: chcon dcn conf and key files
-  shell: "chcon system_u:object_r:container_file_t:s0 {{ item }}"
-  loop:
-    - "{{ keyring }}"
-    - "{{ conf }}"
+  - name: chown dcn conf file
+    shell: "chown root:root {{ conf }}"
 
-- name: collect list of /etc/ceph
-  shell: "ls -l /etc/ceph/"
-  register: ls_ceph
+  - name: Upload ceph keyrings
+    synchronize:
+      mode: push
+      dest: "{{ keyring }}"
+      src: "dcn_ceph_data/client.{{ ceph_cluster_name }}.glance.keyring"
 
-- name: show /etc/ceph
-  debug:
-    msg: "{{ ls_ceph.stdout_lines }}"
-  
-- name: set rbd command fact
-  set_fact:
-    rbd: "podman exec ceph-mon-`hostname` rbd --conf {{ conf }} --id {{ dcn }}.glance --keyring {{ keyring }}"
+  - name: chown dcn keyring
+    shell: "chown 167:167 {{ keyring }}"
 
-- name: Test ceph client connection by writing an object
-  shell: "{{ rbd }} create --size 1024 images/test_object_from_central"
-  register: ceph_write
+  - name: chcon dcn conf and key files
+    shell: "chcon system_u:object_r:container_file_t:s0 {{ item }}"
+    loop:
+      - "{{ keyring }}"
+      - "{{ conf }}"
 
-- name: Test ceph client connection by writing an object
-  shell: "{{ rbd }} ls images"
-  register: ceph_read
+  - name: Collect list of /etc/ceph
+    shell: "ls -l /etc/ceph/"
+    register: ls_ceph
 
-- name: show ceph client test results
-  debug:
-    msg: "Write (should be empty): {{ ceph_write.stdout_lines }} | Read: {{ ceph_read.stdout_lines }}"
+  - name: Show /etc/ceph
+    debug:
+      msg: "{{ ls_ceph.stdout_lines }}"
 
-- name: Clean up after testing by deleteing test object
-  shell: "{{ rbd }} rm images/test_object_from_central"
-  register: ceph_write
+  - name: Set rbd command fact
+    set_fact:
+      rbd: "podman exec ceph-mon-`hostname` rbd --conf {{ conf }} --id {{ ceph_cluster_name }}.glance --keyring {{ keyring }}"
+
+  - name: Test ceph client connection by writing an object
+    shell: "{{ rbd }} create --size 1024 images/test_object_from_{{ inventory_hostname }}"
+    register: ceph_write
+
+  - name: Test ceph client connection by reading an object
+    shell: "{{ rbd }} ls images"
+    register: ceph_read
+
+  - name: Show ceph client test results
+    debug:
+      msg: "Write (should be empty): {{ ceph_write.stdout_lines }} | Read: {{ ceph_read.stdout_lines }}"
+
+  - name: Clean up after testing by deleteing test object
+    shell: "{{ rbd }} rm images/test_object_from_{{ inventory_hostname }}"
+    register: ceph_write

--- a/glance/ansible/tasks/install_client.yml
+++ b/glance/ansible/tasks/install_client.yml
@@ -1,6 +1,7 @@
 ---
 - when:
     # does not need to be configured to talk to itself
+    - ceph_cluster_host is defined
     - ceph_cluster_host != inventory_hostname
     # dcn nodes do not talk to eachother
     - not (ceph_cluster_host|regex_search("^dcn") and
@@ -50,10 +51,12 @@
     shell: "chown 167:167 {{ keyring }}"
 
   - name: chcon dcn conf and key files
-    shell: "chcon system_u:object_r:container_file_t:s0 {{ item }}"
+    shell: "chcon system_u:object_r:container_file_t:s0 {{ inner_item }}"
     loop:
       - "{{ keyring }}"
       - "{{ conf }}"
+    loop_control:
+      loop_var: inner_item
 
   - name: Collect list of /etc/ceph
     shell: "ls -l /etc/ceph/"

--- a/glance/ansible/tasks/make_client.yml
+++ b/glance/ansible/tasks/make_client.yml
@@ -1,29 +1,30 @@
 ---
-- when: host == inventory_hostname
+- when:
+    - ceph_cluster_host == inventory_hostname
   block:
     - name: download ceph configuration file
       synchronize:
         mode: pull
-        src: "/etc/ceph/{{ dcn }}.conf"
-        dest: "dcn_ceph_data/{{ dcn }}.conf"
+        src: "/etc/ceph/{{ ceph_cluster_name }}.conf"
+        dest: "dcn_ceph_data/{{ ceph_cluster_name }}.conf"
 
     - name: set ceph command fact
       set_fact:
-        ceph: "podman exec ceph-mon-{{ host }} ceph --conf /etc/ceph/{{ dcn }}.conf"
+        ceph: "podman exec ceph-mon-{{ ceph_cluster_host }} ceph --conf /etc/ceph/{{ ceph_cluster_name }}.conf"
 
     - name: set ceph keyring fact
       set_fact:
-        keyfile: "/etc/ceph/client.{{ dcn }}.glance.keyring"
+        keyfile: "/etc/ceph/client.{{ ceph_cluster_name }}.glance.keyring"
 
     - name: create ceph client glance keyring
-      shell: "{{ ceph }} auth get-or-create client.{{ dcn }}.glance mon 'profile rbd' osd 'profile rbd pool=images'"
+      shell: "{{ ceph }} auth get-or-create client.{{ ceph_cluster_name }}.glance mon 'profile rbd' osd 'profile rbd pool=images'"
 
     - name: export ceph client glance keyring to file
-      shell: "{{ ceph }} auth get client.{{ dcn }}.glance > {{ keyfile }}"
+      shell: "{{ ceph }} auth get client.{{ ceph_cluster_name }}.glance > {{ keyfile }}"
 
     - name: download ceph client glance keyrings
       synchronize:
         mode: pull
         src: "{{ keyfile }}"
-        dest: "dcn_ceph_data/client.{{ dcn }}.glance.keyring"
+        dest: "dcn_ceph_data/client.{{ ceph_cluster_name }}.glance.keyring"
 

--- a/glance/ansible/tasks/nova_glance.yml
+++ b/glance/ansible/tasks/nova_glance.yml
@@ -2,6 +2,9 @@
 - name: Get IPs of glance-api servers listening on port 9292
   shell: "netstat -an | grep 9292 | awk {'print $4'}"
   register: netstat_glance_port
+  until: (netstat_glance_port.stdout_lines|length) > 0
+  retries: 5
+  delay: 5
   # we'd prefer to be setting this to the haproxy in front of glance
 
 - when:

--- a/glance/control-plane/deploy.sh
+++ b/glance/control-plane/deploy.sh
@@ -28,7 +28,7 @@ if [[ $HEAT -eq 1 ]]; then
          -e ~/templates/environments/ceph-ansible/ceph-ansible.yaml \
          -e ~/containers-env-file.yaml \
          -e ~/domain.yaml \
-         -e ~/ussuri/standard/overrides.yaml \
+         -e overrides.yaml \
          --stack-only \
          --libvirt-type qemu 2>&1 | tee -a ~/install-overcloud.log
 

--- a/glance/control-plane/deploy.sh
+++ b/glance/control-plane/deploy.sh
@@ -102,6 +102,9 @@ if [[ $CONF -eq 1 ]]; then
          # -e validate_ntp=false \
          # -e ping_test_ips=false \
 
+         # When using the options below be sure to include this:
+         # -e gather_facts=true -e @$DIR/global_vars.yaml \
+
          # Just re-run ceph
          # --tags external_deploy_steps
 

--- a/glance/master.sh
+++ b/glance/master.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# known issues: assumes you have run ironic.sh and glance-container-patch.sh
+
+KILL=1
+
+source ~/stackrc
+if [[ $KILL -eq 1 ]]; then
+    if [[ $(openstack stack list | wc -l) -gt 1 ]]; then
+        echo "Destroying the following deployments"
+        openstack stack list
+        for STACK in $(openstack stack list -f value -c "Stack Name"); do
+            pushd $STACK
+            bash ../../kill.sh $STACK
+            popd
+        done
+    fi
+fi
+
+echo "Standing up control-plane deployment"
+pushd control-plane
+bash deploy.sh
+popd
+
+echo "Verify control-plane is working"
+pushd validate
+bash validate.sh control
+if [[ $? -gt 0 ]]; then
+    echo "Execution of use-controlplane.sh on first controller failed. Aborting."
+    exit 1
+fi
+popd
+
+echo "Standing up dcn0 deployment"
+pushd dcn0
+bash deploy.sh
+if [[ $? -gt 0 ]]; then
+    echo "DCN deployment failed. Aborting."
+    exit 1
+fi
+popd
+
+# echo "Standing up dcn1 deployment"
+# bash dcnN.sh
+
+pushd ansible
+bash run.sh
+if [[ $? -gt 0 ]]; then
+    echo "Ansibile post-tripleo configuration failed. Aborting."
+    exit 1
+fi
+popd
+
+echo "Configure control-plane for testing"
+pushd validate
+bash validate.sh
+popd

--- a/glance/validate/README.md
+++ b/glance/validate/README.md
@@ -1,7 +1,7 @@
 # Validate Glance in DCN Deployment
 
-Run [validate.sh](validate.sh) on undercloud to execute the following
-on the overcloud:
+Run [validate.sh](validate.sh) on undercloud to configure the
+overcloud so you can run the following:
 
 - [use-multistore-glance.sh](use-multistore-glance.sh)
   - If an image named cirros is found delete it

--- a/glance/validate/use-central.sh
+++ b/glance/validate/use-central.sh
@@ -7,7 +7,7 @@ IMAGE=$(cat IMAGE)
 
 function run_on_mon {
     # since it will be run on the controller
-    sudo podman exec ceph-mon-$(hostname) $1
+    sudo podman exec ceph-mon-$(hostname) $1 --cluster central
 }
 
 source control-planerc
@@ -54,7 +54,11 @@ if [ $NOVA -eq 1 ]; then
     openstack keypair create demokp_central > ~/demokp_central.pem 
     chmod 600 ~/demokp_central.pem
 
-    openstack server create --flavor m1.tiny --image $IMAGE --key-name demokp_central vm_central --nic net-id=$netid
+    # have not yet created AZs, so specify non-dcn hypervisor
+    HYPERVISOR=$(openstack hypervisor list -f value -c "Hypervisor Hostname" | grep -v dcn)
+
+    openstack server create --hypervisor-hostname $HYPERVISOR --flavor m1.tiny --image $IMAGE --key-name demokp_central vm_central --nic net-id=$netid
+
     openstack server list
     if [[ $(openstack server list -c Status -f value) == "BUILD" ]]; then
         echo "Waiting one minute for building server to boot"

--- a/glance/validate/use-control-plane.sh
+++ b/glance/validate/use-control-plane.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+if [[ ! -e control-planerc ]]; then
+    echo "control-planerc is missing. aborting."
+    exit 1
+fi
+source control-planerc
+# if you cannot issue a token the control plane isn't working
+openstack token issue -f value -c id
+# pass the return code of token issue
+exit $?

--- a/glance/validate/use-dcn.sh
+++ b/glance/validate/use-dcn.sh
@@ -42,7 +42,7 @@ if [[ $MKAZ -eq 1 ]]; then
     if ! openstack aggregate show $HOST_AGGREGATE >null 2>&1; then
         echo "Creating a host aggregate for $AZ"
         openstack aggregate create $HOST_AGGREGATE --zone $AZ
-        for H in $(openstack hypervisor list -f value -c "Hypervisor Hostname"); do
+        for H in $(openstack hypervisor list -f value -c "Hypervisor Hostname" | grep $AZ); do
             echo "Adding $H to $HOST_AGGREGATE"
             openstack aggregate add host $HOST_AGGREGATE $H
         done
@@ -103,7 +103,7 @@ if [[ $NOVA -eq 1 ]]; then
             openstack network create --internal private-${AZ}
         fi
         PRI_SUBNET_ID=$(openstack network show private-${AZ} -c subnets -f value)
-        if [[ -z $PRI_SUBNET_ID ]]; then
+        if [[ $PRI_SUBNET_ID == '[]' ]]; then
             openstack subnet create private-net-${AZ} \
                       --subnet-range $PRIVATE_NETWORK_CIDR \
                       --network private-${AZ}

--- a/glance/validate/use-multistore-glance.sh
+++ b/glance/validate/use-multistore-glance.sh
@@ -24,6 +24,13 @@ esac
 
 echo "Testing feature $PATCH on stores central and dcn0"
 # -------------------------------------------------------
+echo "Check if glance is working"
+glance image-list
+if [[ $? -gt 0 ]]; then
+    echo "Aborting. Not even 'glance image-list' works."
+    exit 1
+fi
+# -------------------------------------------------------
 # Get image if missing
 NAME=$(cat IMAGE)
 IMG=cirros-0.3.4-x86_64-disk.img

--- a/glance/validate/use-multistore-glance.sh
+++ b/glance/validate/use-multistore-glance.sh
@@ -89,7 +89,7 @@ echo "Looking at glance tasks"
 glance task-list | head -5
 
 echo "Show newest task"
-TASK_ID=$(glance task-list | head -4 | grep processing | awk {'print $2'})
+TASK_ID=$(glance task-list | head -4 | egrep "success|processing" | awk {'print $2'})
 glance task-show $TASK_ID
 echo "Confirm image ID in task"
 glance task-show $TASK_ID | grep $ID
@@ -112,7 +112,7 @@ while [ 1 ]; do
 done
 
 echo "- Use RBD to list images on central"
-sudo podman exec ceph-mon-$(hostname) rbd -p images ls -l
+sudo podman exec ceph-mon-$(hostname) rbd --cluster central -p images ls -l
 
 echo "- Use RBD to list images on dcn0"
 sudo podman exec ceph-mon-$(hostname) rbd --id dcn0.glance --keyring /etc/ceph/client.dcn0.glance.keyring --conf /etc/ceph/dcn0.conf -p images ls -l

--- a/glance/validate/validate.sh
+++ b/glance/validate/validate.sh
@@ -26,6 +26,10 @@ for FILE in $FILES; do
         if [[ $FILE != "control-planerc" && $FILE != "IMAGE" ]]; then
             echo "Running $FILE ..."
             ssh -q -o "StrictHostKeyChecking no" heat-admin@$CONTROLLER "bash $FILE"
+            if [[ $? -gt 0 ]]; then
+                echo "Aborting. Run of $FILE failed."
+                exit 1
+            fi
         fi
     fi
 done

--- a/glance/validate/validate.sh
+++ b/glance/validate/validate.sh
@@ -23,19 +23,10 @@ for FILE in $FILES; do
         exit 1
     else
         scp -q -o "StrictHostKeyChecking no" $FILE heat-admin@$CONTROLLER:/home/heat-admin/
-        if [[ $FILE != "control-planerc" && $FILE != "IMAGE" ]]; then
-            echo "Running $FILE ..."
-            ssh -q -o "StrictHostKeyChecking no" heat-admin@$CONTROLLER "bash $FILE"
-            if [[ $? -gt 0 ]]; then
-                echo "Aborting. Run of $FILE failed."
-                exit 1
-            fi
-        fi
     fi
 done
 
-echo "Echo checking Ceph on $DCN_NAME"
-DCN=$(openstack server list -c Networks -c Name -f value | grep $DCN_NAME | awk {'print $2'} | sed s/ctlplane=//g)
-CMD0="sudo podman exec ceph-mon-\$(hostname) rbd -p images ls -l --cluster $DCN_NAME"
-CMD1="sudo podman exec ceph-mon-\$(hostname) rbd -p vms ls -l --cluster $DCN_NAME"
-ssh -q -o "StrictHostKeyChecking no" heat-admin@$DCN "$CMD0; $CMD1"
+echo -e "Files transferred. To continue do the following:\n"
+echo "  ssh heat-admin@$CONTROLLER"
+echo "  bash use-multistore-glance.sh; bash use-central.sh; bash use-dcn.sh"
+echo ""

--- a/kill.sh
+++ b/kill.sh
@@ -22,3 +22,11 @@ fi
 if [[ -d config-download ]]; then
     rm -v -rf config-download
 fi
+
+# delete exported control-plane file if it exsits
+if [[ -e ~/control-plane-export.yaml ]]; then
+    rm -v ~/control-plane-export.yaml
+fi
+
+# delete all RC files
+find . -name ${CLOUD}rc -exec rm -f {} \;


### PR DESCRIPTION
With the tag central-to-edge-ceph-only glance on the central site can write to ceph on the dcn site but glance on the edge site cannot write to ceph on the central site. 

This change configures two way ceph clients so that glance on the central site can write to ceph on the dcn site and glance on the edge site can write to ceph on the central site. 

One usecase for two way ceph clients this is snapshots; e.g. boot an instance on a dcn site, snapshot it and then boot an instance of that snapshot on the central site. In order for that snapshot to reach the central site the glance at the dcn site needs to be able to write to the central ceph.